### PR TITLE
Calibration v2

### DIFF
--- a/lib/TestBench/GenyApi.py
+++ b/lib/TestBench/GenyApi.py
@@ -1,0 +1,83 @@
+import socket
+import json
+
+class GenyApi:
+    class GenyVersion:
+        YC99T_5C = 'Geny YC99T_5C'
+        YC99T_3C = 'Geny YC99T_3C'
+    
+    def __init__(self, id:str, port:int=1234):
+        '''
+            parameters:
+                -id `id`: nametag for geny connection
+                -port `int`: port where the service is listening to
+        '''
+        self.id=id
+        self.ipAddress = 'localhost'
+        self.port = port
+        
+        self.streamBuffer = 512
+        self.tcpClient = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.tcpClient.connect((self.ipAddress, self.port))
+        
+    def transaction(self, api:bytearray, timeout:int=6)->str:
+        self.tcpClient.settimeout(timeout)
+        self.tcpClient.send(api)
+        recvData = self.tcpClient.recv(self.streamBuffer)
+        return recvData.decode('utf-8')
+    
+    def open(self, serialPort:str, baudrate:int, testBenchVendor:str):
+        '''
+            attach serial port to test bench. Raise exception if failed
+        
+            parameters:
+                serialPort `str`: usb serial port
+                baudRate `int`: baud rate used for usb serial
+                testBenchVendor `str`: test bench will be used. Use get vendor list to show all supported testbench
+            
+            return:
+                - True if SUCCESS
+        '''
+        payload = {
+            "id": self.id,
+            "testbenchVendor": testBenchVendor,
+            "serialPort": serialPort,
+            "baudRate": baudrate
+        }
+        payload = json.dumps(payload)
+        api = f'{self.id}#systemAddTestBench_v1?{payload}'.encode('utf-8')
+        response = self.transaction(api)
+        if 'OK' in response:
+            return True
+        else:
+            raise Exception(f'Could not open test bench. Error Message: {response}')
+        
+    def close(self):
+        '''
+            Close geny connection
+        '''
+        payload = {
+            "id": self.id
+        }
+        payload = json.dumps(payload)
+        api = f'{self.id}#systemCloseTestBench_v1?{payload}'.encode('utf-8')
+        response = self.transaction(api)
+        if 'OK' in response:
+            return True
+        else:
+            raise Exception(f'Could not close test bench. Error Message: {response}')
+
+    def closeAll(self):
+        '''
+            Close all geny connections
+        '''
+        payload = {
+            "id" : "*"
+        }
+        payload = json.dumps(payload)
+        api = f'{self.id}#systemCloseTestBench_v1?{payload}'.encode('utf-8')
+        response = self.transaction(api)
+        if 'OK' in response:
+            return True
+        else:
+            raise Exception(f'Could not close test bench. Error Message: {response}')

--- a/lib/TestBench/GenyTestBench.py
+++ b/lib/TestBench/GenyTestBench.py
@@ -1,5 +1,6 @@
 import math
 from datetime import datetime, timedelta
+from serial import Serial
 
 from typing import Union
 from .GenyUtil import VoltageRange, VoltageRangeError, ElementSelector, PowerSelector
@@ -31,6 +32,7 @@ class GenyTestBench(GenySys):
             
     def __del__(self):
         print('Testbench deleted')
+        self.serialMonitor.stopMonitor()
     
     def setMode(self, mode:Mode):
         self.mode = mode
@@ -45,7 +47,15 @@ class GenyTestBench(GenySys):
 
 
     # API
+    def getSerial(self)->Serial:
+        '''
+            Get Serial object
+        '''
+        return self.serialMonitor.ser
+    
     def open(self):
+        print('[GenyTestBench] Establishing connection to geny')
+        print('[GenyTestBench] Start monitor')
         self.serialMonitor.startMonitor()
         
         buffer = self.connect()
@@ -64,9 +74,12 @@ class GenyTestBench(GenySys):
         try:
             self.response.extractDataFrame(result)
             if self.response.getErrorCode() == 0:
+                self.serialMonitor.stopMonitor()
                 return True
+            self.serialMonitor.stopMonitor()
             return False
         except:
+            self.serialMonitor.stopMonitor()
             return False
     
     def setElementSelector(self, elementSelector:[ElementSelector.EnergyErrorCalibration, ElementSelector.ThreePhaseAcStandard]):

--- a/lib/TestBench/GenyTestBench.py
+++ b/lib/TestBench/GenyTestBench.py
@@ -29,10 +29,6 @@ class GenyTestBench(GenySys):
         
         # Set mode
         self.setMode(self.mode)
-            
-    def __del__(self):
-        print('Testbench deleted')
-        self.serialMonitor.stopMonitor()
     
     def setMode(self, mode:Mode):
         self.mode = mode

--- a/lib/TestBench/src/SerialMonitor.py
+++ b/lib/TestBench/src/SerialMonitor.py
@@ -49,6 +49,13 @@ class SerialMonitor:
         '''
             Run serial handler monitor
         '''
+        print('[SerialHandler] check serial is open')
+        if not self.ser.is_open:
+            print('[SerialHandler] opening serial')
+            self.ser.open()
+        else:
+            print('[SerialHandler] serial already open')
+            
         print('[SerialHandler] starting serialMonitor')
         try:
             self.service.start()
@@ -61,11 +68,15 @@ class SerialMonitor:
         '''
             Stop serial handler monitor
         '''
-        print('[SerialHandler] starting serialMonitor')
+        print('[SerialHandler] stoping serialMonitor')
         self.isRunning = False
-        if isBlocking:
+        if isBlocking:                
             while self.serviceIsActive:
                 time.sleep(0.1)
+        
+        # make sure to close serial port
+        if self.ser.is_open:
+            self.ser.close()
         
     def transaction(self, dataFrame:bytearray, timeout=5) -> bytearray:
         '''
@@ -109,5 +120,8 @@ class SerialMonitor:
                         if self.callback != None:
                             self.callback(tempBuffer)
                         break
+        print('[SerialHandler] closing serial')
+        self.ser.close()
         print('[SerialHandler] serialMonitor has been terminated')
         self.serviceIsActive = False
+        

--- a/src/TestbenchService.py
+++ b/src/TestbenchService.py
@@ -33,12 +33,13 @@ class TestBenchService:
     def start(self):
         self.mSocket.bind((self.ipAddress, self.port))
         self.mSocket.listen()
-        self.mSocket.settimeout(0.1)
+        # self.mSocket.settimeout(0.1)
         print(f'Server is listening to {self.ipAddress} {self.port}')
         while True:
             try:
                 clientSocket, clientAddress = self.mSocket.accept()
             except TimeoutError:
+                sleep(0.1)
                 continue
 
             # Create handler
@@ -125,10 +126,12 @@ class TestBenchService:
         try:
             if testBenchVendor == 'Geny YC99T_5C':
                 newTestbench = GenyTestBench(usbport=serialport, baudrate=baudRate)
+                newTestbench.open()
                 self.testBench[id] = newTestbench
                 isOk = True
             elif testBenchVendor == 'Geny YC99T_3C':
                 newTestbench = GenyTestBench(usbport=serialport, baudrate=baudRate)
+                newTestbench.open()
                 self.testBench[id] = newTestbench
                 isOk = True
         except serial.SerialException as e:

--- a/src/TestbenchService.py
+++ b/src/TestbenchService.py
@@ -1,0 +1,260 @@
+import pathlib
+import site
+CURRENT_PATH = pathlib.Path(__file__)
+site.addsitedir(CURRENT_PATH)
+
+import socket
+import serial
+import json
+from typing import Tuple
+from threading import Thread
+from time import sleep
+from lib.TestBench.GenyTestBench import GenyTestBench
+
+class TestBenchService:
+    SupportedTestBench = {
+        "Geny YC99T_5C",
+        "Geny YC99T_3C"
+    }
+    
+    def __init__(self, ipAddress:str='localhost', port:int=1234):
+        self.ipAddress = ipAddress
+        self.port = port
+        self.mSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.testBench = {}
+                
+        self.api = {
+            "systemGetSupportedTestBench": self.system_getSupportedTestBench,
+            "systemAddTestBench": self.systen_addTestBench,
+            "systemCloseTestBench": self.system_closeTestBench,
+        }
+    
+    def start(self):
+        self.mSocket.bind((self.ipAddress, self.port))
+        self.mSocket.listen()
+        self.mSocket.settimeout(0.1)
+        print(f'Server is listening to {self.ipAddress} {self.port}')
+        while True:
+            try:
+                clientSocket, clientAddress = self.mSocket.accept()
+            except TimeoutError:
+                continue
+
+            # Create handler
+            handler = Thread(target=self.clientHandler, daemon=True, args=(clientSocket,))
+            handler.start()
+            sleep(0.01)
+            
+    def parseRequest(self, requestBytes:bytes) -> Tuple[str, str, str]:
+        '''
+            split request frame from client
+            
+            parameters:
+                - requestBytes
+            
+            return:
+                tuple of agentName `str`, request API `str`, api data `str` (loaded as dict)
+        '''
+        _req = requestBytes.decode('utf-8')
+        _req = _req.split('#')
+        
+        agentName = _req[0]
+        api, data = _req[1].split('?')
+        # print(f'Agent name : {agentName}')
+        # print(f'Request API: {api}')
+        # print(f'API data   : {data}')
+        data = json.loads(data)
+        return agentName, api, data
+        
+    
+    def clientHandler(self, clientSocket:socket.socket):
+        '''
+            Thread function that will handle request from client. Each API have it's function to handle request, and the response will send inside api funtion
+            prameters:
+                - clientSocket `socket`:
+        '''
+        print('Receive Connection')
+        while True:
+            try:
+                data = clientSocket.recv(516)
+                if not data:
+                    break
+                
+                agentName, api, data = self.parseRequest(data)
+                if api not in self.api:
+                    clientSocket.send(b'NA')
+                elif 'system' in api:
+                    self.api[api](data, clientSocket)
+                else:
+                    testBench = self.testBench[agentName]
+                    self.api[api](testBench, data, clientSocket)    
+            except TimeoutError:
+                break
+        clientSocket.close()
+        print('[Client Handler] Socket closed')
+                
+    #
+    # HANDLERS
+    #
+    def system_getSupportedTestBench(self, apiData:dict, socketClient:socket.socket):
+        '''
+            apiData will be ignored
+        '''
+        
+    
+    def systen_addTestBench(self, apiData:dict, socketClient:socket.socket):
+        '''
+            apiData keys:
+                - id `str`: used for testbench id
+                - testbenchVendor `str`: vendor of the test bench supported testbench: [Geny YC99T_5C, Geny YC99T_3C]
+                - serialport `str`: usb serial port
+                - baudRate `int`: baudate for the serial
+        '''
+        try:
+            id = apiData['id']
+            testBenchVendor = apiData['testbenchVendor']
+            serialport = apiData['serialPort']
+            baudRate = apiData['baudRate']
+        except:
+            socketClient.send(b'NA. Key error')
+            return
+        
+        # Creating Connection to test bench
+        isOk = False
+        try:
+            if testBenchVendor == 'Geny YC99T_5C':
+                newTestbench = GenyTestBench.GenyTestBench(usbport=serialport, baudrate=baudRate)
+                self.testBench[id] = newTestbench
+                isOk = True
+            elif testBenchVendor == 'Geny YC99T_3C':
+                newTestbench = GenyTestBench.GenyTestBench(usbport=serialport, baudrate=baudRate)
+                self.testBench[id] = newTestbench
+                isOk = True
+        except serial.SerialException as e:
+            socketClient.send(f'NA. {str(e)}'.encode('utf-8'))
+            return
+        
+        if isOk:
+            socketClient.send(b'OK')
+        else:
+            socketClient.send(b'NA')
+        
+    def system_closeTestBench(self, apiData:dict, socketClient:socket.socket):
+        '''
+            apiData keys:
+                - id `str`: id of the test bench that will be closed. if it is '*' then all test bench will be closed
+        '''
+        try:
+            id = apiData['id']
+        except:
+            socketClient.send(b'NA, Key error')
+            return
+        
+        # Close testbench
+        if id == '*':
+            tbIds = list(self.testBench.keys())
+            for id in tbIds:
+                testbench = self.testBench[id]
+                del testbench
+        else:
+            if id not in self.testBench:
+                socketClient.send(b'NA. Testbench is not exist')
+            self.testBench[id].close()
+            del self.testBench[id]
+            print('Current testbench:', self.testBench)
+            
+        socketClient.send(b'OK')
+    
+class GenyApi:
+    def __init__(self, id:str):
+        self.id=id
+        self.ipAddress = 'localhost'
+        self.port = 1234
+        
+        self.streamBuffer = 512
+        self.tcpClient = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.tcpClient.connect((self.ipAddress, self.port))
+        
+    def transaction(self, api:bytearray, timeout:int=6)->str:
+        self.tcpClient.settimeout(timeout)
+        self.tcpClient.send(api)
+        recvData = self.tcpClient.recv(self.streamBuffer)
+        return recvData.decode('utf-8')
+    
+    def open(self, serialPort:str, baudrate:int, testBenchVendor:str):
+        '''
+            attach serial port to test bench. Raise exception if failed
+        
+            parameters:
+                serialPort `str`: usb serial port
+                baudRate `int`: baud rate used for usb serial
+                testBenchVendor `str`: test bench will be used. Use get vendor list to show all supported testbench
+            
+            return:
+                - True if SUCCESS
+        '''
+        payload = {
+            "id": self.id,
+            "testbenchVendor": testBenchVendor,
+            "serialPort": serialPort,
+            "baudRate": baudrate
+        }
+        payload = json.dumps(payload)
+        api = f'{self.id}#systemAddTestBench?{payload}'.encode('utf-8')
+        response = self.transaction(api)
+        if 'OK' in response:
+            return True
+        else:
+            raise Exception(f'Could not open test bench. Error Message: {response}')
+        
+    
+    def close(self):
+        '''
+            Close geny connection
+        '''
+        payload = {
+            "id": self.id
+        }
+        payload = json.dumps(payload)
+        api = f'{self.id}#systemCloseTestBench?{payload}'.encode('utf-8')
+        response = self.transaction(api)
+        if 'OK' in response:
+            return True
+        else:
+            raise Exception(f'Could not close test bench. Error Message: {response}')
+
+def test():
+    COM_PORT = 'COM1'
+    
+    is_alreadyOpened = False
+    
+    geny = GenyApi('coba')
+    print('Open')
+    try:
+        result = geny.open('COM1', 9600, "Geny YC99T_5C")
+        print(f'Response: {result}')
+    except Exception as e:
+        print('Open failed')
+        if COM_PORT in str(e):
+            print(f'{COM_PORT} already opened')
+            is_alreadyOpened = True
+
+            # print('Close first')
+            # geny.close()
+            # result = geny.open('COM1', 9600, "Geny YC99T_5C")
+            # print(f'Response: {result}')
+        
+    print('Close')
+    result = geny.close()
+    print(f'Response: {result}')
+    
+
+import sys
+argv = sys.argv
+if '-s' in argv:
+    testbenchService = TestBenchService('localhost', 1234)
+    testbenchService.start()
+    while True:
+        sleep(0.1)
+else:
+    test()

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     geny_v1: test for geny testbench test version 1
+    genyservice_v1: test for geny service v1

--- a/test/test_genyService.py
+++ b/test/test_genyService.py
@@ -1,0 +1,166 @@
+import pathlib
+import site
+CURRENT_PATH = pathlib.Path(__file__).parent.absolute()
+site.addsitedir(CURRENT_PATH.parent)
+
+import pytest
+from time import sleep
+from lib.TestBench.GenyApi import GenyApi
+from src.TestbenchService import TestBenchService
+
+@pytest.mark.parametrize('serial_port', [
+    'COM1'
+])
+@pytest.mark.parametrize('geny_version', [
+    GenyApi.GenyVersion.YC99T_5C
+])
+
+@pytest.mark.genyservice_v1
+def test_serviceOpenClose(serial_port, geny_version):
+    '''
+        # Manually test
+            Using serial snipping tool ex: Eltima serial monitor
+        # Automatic test
+            Create Serial object to make sure the serial is opened or not
+    
+        1. Try open new connection to Geny, there will be 2 possibility:
+            1.1 The server will open SUCCESS fully. Then pass to next test
+            1.2 The server will reject because it has already exists. Close it and reopen.
+        2. Close the connection
+    
+    '''
+    from serial import Serial
+    
+    # genyService = TestBenchService('localhost', 1234)
+    # genyService.start()
+    
+    geny = GenyApi('Client1')
+    print('Open')
+    
+    # create geny connection
+    is_alreadyOpened = False
+    try:
+        result = geny.open('COM1', 9600, geny_version)
+        print(f'Response: {result}')
+        assert result
+    except Exception as e:
+        errorMessage = str(e)
+        print(f'Open failed. {str(e)}')
+        if 'FileNotFoundError' in errorMessage:
+            is_alreadyOpened = False
+        elif 'PermissionError' in errorMessage:    
+            is_alreadyOpened = True
+    
+    # recreate the geny connection
+    if is_alreadyOpened: 
+        print('Connection already exist. Close and reopen connectino')
+        result = geny.close()
+        print(f'Close connection: {result}')
+        assert result
+        
+        # Create Serial instance to open serial_port. If opened, it already closed on geny.close()
+        print('Check serial port')
+        temp = Serial(serial_port)
+        print('Is closed? '+'PASSED' if temp.is_open else 'FAILED')
+        assert temp.is_open
+        temp.close()
+        
+        result = geny.open('COM1', 9600, geny_version)
+        print(f'Reopen connection: {result}')
+        assert result
+        
+        # Create Serial instance to open serial_port. If could not opened, it already open on geny.open()
+        print('Check serial port')
+        try:
+            temp = Serial(serial_port)
+            temp.close()
+        except:
+            print('Is opened? '+'PASSED' if temp.is_open else 'FAILED')
+            assert False # force false because the serial could open (should be couldn't opened)
+        
+        
+    print('Close')
+    result = geny.close()
+    print(f'Response: {result}')
+    assert result
+
+@pytest.mark.genyservice_v1
+def test_duplicatedConnection(serial_port, geny_version):
+    '''
+        # Manually test
+            Using serial snipping tool ex: Eltima serial monitor
+        # Automatic test
+            Create Serial object to make sure the serial is opened or not
+    
+        # Test repro
+            1. Close all connection
+            2. Open connection
+            3. Open connection again and make sure the serial is already opened
+            2. Close the connection
+    
+    '''
+    from serial import Serial
+    
+    # genyService = TestBenchService('localhost', 1234)
+    # genyService.start()
+    
+    geny = GenyApi('Client1')
+    
+    print('Close all connection')
+    result = geny.closeAll()
+    print(f'Response: {result}')
+    
+    print('Open first')
+    result = geny.open('COM1', 9600, geny_version)
+    print(f'Response: {result}')
+    
+    # Re open connection
+    is_alreadyOpened = False
+    try:
+        print('Open Second')
+        result = geny.open('COM1', 9600, geny_version)
+        print(f'Response: {result}')
+        assert result
+    except Exception as e:
+        errorMessage = str(e)
+        print(f'Open failed. {str(e)}')
+        if 'FileNotFoundError' in errorMessage:
+            is_alreadyOpened = False
+        elif 'PermissionError' in errorMessage:    
+            is_alreadyOpened = True
+    
+    # recreate the geny connection
+    if is_alreadyOpened: 
+        print('Connection already exist. Close and reopen connectino')
+        result = geny.close()
+        print(f'Close connection: {result}')
+        assert result
+        
+        # Create Serial instance to open serial_port. If opened, it already closed on geny.close()
+        print('Check serial port')
+        temp = Serial(serial_port)
+        print('status: ' + ('PASSED' if temp.is_open else 'FAILED'))
+        assert temp.is_open
+        temp.close()
+        
+        result = geny.open('COM1', 9600, geny_version)
+        print(f'Reopen connection: {result}')
+        assert result
+        
+        # Create Serial instance to open serial_port. If could not opened, it already open on geny.open()
+        print('Check serial port')
+        try:
+            temp = Serial(serial_port)
+            temp.close()
+            assert False # force false because the serial could open (should be couldn't opened)
+        except:
+            print('status: '+ ('PASSED' if not temp.is_open else 'FAILED'))
+        
+        
+    print('Close')
+    result = geny.close()
+    print(f'Response: {result}')
+    assert result
+
+# test_serviceOpenClose('COM1', GenyApi.GenyVersion.YC99T_5C)
+test_duplicatedConnection('COM1', GenyApi.GenyVersion.YC99T_5C)

--- a/test/test_genyService.py
+++ b/test/test_genyService.py
@@ -50,6 +50,8 @@ def test_serviceOpenClose(serial_port, geny_version):
             is_alreadyOpened = False
         elif 'PermissionError' in errorMessage:    
             is_alreadyOpened = True
+        elif 'Could not exclusively lock port' in errorMessage:
+            is_alreadyOpened = True
     
     # recreate the geny connection
     if is_alreadyOpened: 
@@ -127,6 +129,8 @@ def test_duplicatedConnection(serial_port, geny_version):
         if 'FileNotFoundError' in errorMessage:
             is_alreadyOpened = False
         elif 'PermissionError' in errorMessage:    
+            is_alreadyOpened = True
+        elif 'Could not exclusively lock port' in errorMessage:
             is_alreadyOpened = True
     
     # recreate the geny connection

--- a/test/test_genyTestbench.py
+++ b/test/test_genyTestbench.py
@@ -3,32 +3,56 @@ import site
 CURRENT_PATH = pathlib.Path(__file__).parent.absolute()
 site.addsitedir(CURRENT_PATH.parent)
 
+import gc
 import pytest
 from time import sleep
 from lib.TestBench.GenyTestBench import GenyTestBench
 
+@pytest.mark.parametrize('serial_port', [
+    'COM1'
+])
+
+
 @pytest.mark.geny_v1
-def test_serialPort():
+def test_serialPort(serial_port):
     '''
         Ekspektasi:
-            1. Saat pembuatan object serial port akan langsung di buka.
-            2. Saat object.close() serial akan tertutup. (FYI: Terdapat background process <serialMonitor> yang perlu di stop pula)
-            3. Saat object.open() serial akan terbuka kembali.
-            4. Saat object di delete, serial akan tertutup
-    '''
+            1. Serial port automatically opened when generate new object.
+            2. Serial port will closed on object.close(). (FYI: There is thread named SerialMonitor that also need to be stopped)
+            3. Serial port will reopen when object.open(). Test bench will switched to rs232 mode.
+            4. Serial port will closed after delete the object. We may need to gc.collect().
+    '''    
+    geny = GenyTestBench(usbport=serial_port, baudrate=115200)
+    serialPort = geny.getSerial()
     
-    geny = GenyTestBench(usbport='com1', baudrate=115200)
-    serialPort = geny.serialMonitor.ser
-    # assert serialPort.is_open()
-    print('Stop monitor')
-    geny.serialMonitor.stopMonitor()
+    # It is okay if occur exception the main expectation is the serial port could be opened or closed
+    try:
+        geny.open()
+    except:
+        pass
+    assert serialPort.is_open == True
     
-    print('Force close serialport')
-    serialPort.close()
-    print('Start monitor')
-    serialPort.open()
+    try:
+        geny.close()
+    except:
+        pass
+    assert serialPort.is_open == False
     
-    sleep(2)
+    # Open it again
+    try:
+        geny.open()
+    except:
+        pass
+    assert serialPort.is_open 
     
+    # Delete the object, serial should closed. Indicated we could generate new Serial object
+    from serial import Serial
+    print('Test delete object')
+    del geny
+    gc.collect()
 
-test_serialPort()
+    isOk = False
+    newSer = Serial(port=serial_port)
+    isOk = newSer.is_open
+    assert isOk    
+    sleep(2)


### PR DESCRIPTION
# Serial connection fix
## For GENY Test Bench
1. Serial port automatically opened when generate new object.
2. Serial port will closed on object.close(). (FYI: There is thread named SerialMonitor that also need to be stopped)
3. Serial port will reopen when object.open(). Test bench will switched to rs232 mode.
4. Serial port will closed after delete the object. We may need to gc.collect().

## For GENY API
I create function API to make bridge between developer to geny service. This PR refer to Open/Close mechanism that described at this point:
1. Serial will open on `.open()`
2. Serial will stoped on `.close()`